### PR TITLE
Fixed link to abandoned shopping cart blog post

### DIFF
--- a/docs/learn/samples/saga.md
+++ b/docs/learn/samples/saga.md
@@ -5,5 +5,5 @@ Clone the sample: [GitHub Repository](https://github.com/MassTransit/Sample-Shop
 This was a fun sample, created in response to a [blog post][1] on how to send an email to a customer
 that abandoned a shopping cart. My response to that post is [located here][2].
 
-[1]: http://joshkodroff.com/blog/2015/08/21/an-elegant-abandoned-cart-email-using-nservicebus/
+[1]: http://joshkodroff.com/2015/08/21/an-elegant-abandoned-cart-email-using-nservicebus/
 [2]: http://blog.phatboyg.com/general/2015/09/12/sagas-state-machines-and-abandoned-carts.html


### PR DESCRIPTION
Looks like that link has moved. The new one doesn't have `/blog` in the URL.

![image](https://user-images.githubusercontent.com/7291324/33464628-415eb138-d611-11e7-9e34-e211dd6140bd.png)
